### PR TITLE
Remove api_transaction_id from master.rb

### DIFF
--- a/lib/yesmail/master.rb
+++ b/lib/yesmail/master.rb
@@ -3,9 +3,7 @@ module Yesmail
   class Master
     # @attribute api_id [String] the master_id that identifies
     #     your account with Yesmail
-    # @attribute api_transaction_id [String] the transactionID
-    #     that ids this transaction with Yesmail
-    attr_accessor :api_id, :api_transaction_id
+    attr_accessor :api_id
 
     def path
       '/masters'
@@ -16,11 +14,6 @@ module Yesmail
     def subscriber_message_data
       {
         masterId: api_id,
-        attributes: {
-          attributes: [
-              { name: 'transactionID', value: api_transaction_id }
-          ]
-        }
       }
     end
   end

--- a/lib/yesmail/subscriber.rb
+++ b/lib/yesmail/subscriber.rb
@@ -72,7 +72,6 @@ module Yesmail
       end
     end
 
-    # This will
     def api_get
       handler.get({email: email}, path)
     end


### PR DESCRIPTION
Removed the api_transaction_id from the master because it is not in the Yesmail api spec. It will now be placed into the subscriber through the `:attribute_data`
