### PR TITLE
remove unused user_id, clean up comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yesmail
 
-A RubyGem to interact with the Yesmail api (http://www.yesmail.com/)
+A RubyGem to interact with the Yesmail API (http://www.yesmail.com/)
 
 ## Installation
 
@@ -34,6 +34,7 @@ yesmail is written and maintained by ApartmentList.com:
 
 Contributors include:
 
+ * [Heidi Galbraith] (https://github.com/heidiho)
  * [Wes Hunt](https://github.com/wesdotcool)
  * [Jon Snitow](https://github.com/otherjonvb)
  * [@jakeonrails](http://twitter.com/jakeonrails)

--- a/lib/yesmail/configuration.rb
+++ b/lib/yesmail/configuration.rb
@@ -1,10 +1,10 @@
-# This holds the information that Yesmail needs before it allows any api calls.
-# These values will be placed in json when sending Yesmail queries
+# This holds the information that Yesmail needs before it allows any API calls.
+# These values will be placed in JSON when sending Yesmail queries.
 #
 # The Yesmail module initializes its configuration on startup. You can change
 # it at the command line:
-# Yesmail::configuratoin.username = 'blah'
-# Yesmail::configuratoin.division = 'Retention'
+# Yesmail::configuration.username = 'blah'
+# Yesmail::configuration.division = 'Retention'
 
 module Yesmail
   class Configuration

--- a/lib/yesmail/master.rb
+++ b/lib/yesmail/master.rb
@@ -1,7 +1,7 @@
-# This class is used to represent a single transaction with Yesmail
+# This class is used to represent a single transaction with Yesmail.
 module Yesmail
   class Master
-    # @attribute api_id [String] the master_id that identifies
+    # @attribute api_id [String] The master_id that identifies
     #     your account with Yesmail
     attr_accessor :api_id
 
@@ -9,8 +9,8 @@ module Yesmail
       '/masters'
     end
 
-    # @return [Hash] represents the masterId and transactionID
-    #     part of the outgoing JSON request to Yesmail
+    # @return [Hash] A hash representing the masterId part of the outgoing JSON
+    #     request to Yesmail
     def subscriber_message_data
       {
         masterId: api_id,

--- a/lib/yesmail/poster.rb
+++ b/lib/yesmail/poster.rb
@@ -1,5 +1,5 @@
-# This class handles the bare communications with Yesmail
-# It uses HTTParty for the underlying http requests
+# This class handles the bare communications with Yesmail.
+# It uses HTTParty for the underlying HTTP requests.
 
 require 'httparty'
 module Yesmail
@@ -24,8 +24,8 @@ module Yesmail
       hash
     end
 
-    # This will handle an http post, and return the body of the response
-    # @param post_data [String] data that will be placed in the post body
+    # This will handle an HTTP post, and return the body of the response.
+    # @param post_data [String] The data that will be placed in the post body
     # @param path [String] The URL to post the data
     def post(post_data, path)
       response = self.class.post(path, options(post_data, true))

--- a/lib/yesmail/side_table.rb
+++ b/lib/yesmail/side_table.rb
@@ -1,5 +1,6 @@
 # This class handles the side table part of the outgoing JSON message to
-# Yesmail
+# Yesmail.  A side table is a table in your database related to the Yesmail
+# users table.
 #
 # According to the online API, the side table is structured as such:
 #
@@ -27,9 +28,8 @@ module Yesmail
       @rows ||= { rows: [] }
     end
 
-    # This probably the only method you need to call.
+    # This is probably the only method you need to call.
     def data_to_rows(data, subscriber = nil)
-      #increment the sort id
       @sort_id += 1
       data.merge!({ email: subscriber.email })
       columns = { columns: [] }

--- a/spec/lib/yesmail/subscriber_spec.rb
+++ b/spec/lib/yesmail/subscriber_spec.rb
@@ -58,7 +58,7 @@ module Yesmail
     describe '#api_update' do
       let(:subscriber) { Subscriber.new }
       it 'sets allowResubscribe to true' do
-        stub(subscriber).get_user_id_from_email { 1 }
+        stub(subscriber).subscriber_id
 
         mock(subscriber.handler).update(
           post_data = hash_including(allowResubscribe: true),


### PR DESCRIPTION
User id appears to be assigned by Yesmail regardless of whether we provide it.
@jakeonrails @otherjonvb @wesdotcool 
